### PR TITLE
chore: add dist to tsconfig ignore list

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "compilerOptions": {
+    // Enable latest features
+    "lib": ["ESNext", "DOM"],
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleDetection": "force",
+    "jsx": "react-jsx",
+    "allowJs": true,
+
+    "types": ["bun", "node"],
+
+    // Bundler mode
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+
+    // Best practices
+    "strict": true,
+    "skipLibCheck": true,
+    "noFallthroughCasesInSwitch": true,
+
+    // Some stricter flags (disabled by default)
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noPropertyAccessFromIndexSignature": false
+  },
+  "exclude": ["tests", "dist"]
+}


### PR DESCRIPTION
## Summary
- Add `dist` to the `exclude` list in `tsconfig.json` to prevent TypeScript from checking build output files

## Test plan
- [ ] Verify `tsconfig.json` excludes `dist` directory
- [ ] Confirm TypeScript compilation still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)